### PR TITLE
Modified worker creation for ES5 compatibility

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ function buildWorkerCode(source, sourcemap = null, inline = true, preserveSource
             return `\
 /* eslint-disable */\n\
 import {createInlineWorkerFactory} from 'rollup-plugin-web-worker-loader::helper';\n\
-const WorkerFactory = createInlineWorkerFactory(${source.substring(0, source.length - 1)}, ${sourcemap ? `'${sourcemap.toUrl()}'` : 'null'});\n\
+var WorkerFactory = createInlineWorkerFactory(${source.substring(0, source.length - 1)}, ${sourcemap ? "'" + sourcemap.toUrl() + "'" : 'null'});\n\
 export default WorkerFactory;\n\
 /* eslint-enable */\n`;
         }
@@ -46,7 +46,7 @@ export default WorkerFactory;\n\
         return `\
 /* eslint-disable */\n\
 import {createBase64WorkerFactory} from 'rollup-plugin-web-worker-loader::helper';\n\
-const WorkerFactory = createBase64WorkerFactory('${Buffer.from(source, enableUnicode ? 'utf16le' : 'utf8').toString('base64')}', ${sourcemap ? `'${sourcemap.toUrl()}'` : 'null'}, ${enableUnicode.toString()});\n\
+var WorkerFactory = createBase64WorkerFactory('${Buffer.from(source, enableUnicode ? 'utf16le' : 'utf8').toString('base64')}', ${sourcemap ? "'" + sourcemap.toUrl() + "'" : 'null'}, ${enableUnicode.toString()});\n\
 export default WorkerFactory;\n\
 /* eslint-enable */\n`;
     }
@@ -54,7 +54,7 @@ export default WorkerFactory;\n\
     return `\
 /* eslint-disable */\n\
 import {createURLWorkerFactory} from 'rollup-plugin-web-worker-loader::helper';\n\
-const WorkerFactory = createURLWorkerFactory('${source}');\n\
+var WorkerFactory = createURLWorkerFactory('${source}');\n\
 export default WorkerFactory;\n\
 /* eslint-enable */\n`;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ function buildWorkerCode(source, sourcemap = null, inline = true, preserveSource
             return `\
 /* eslint-disable */\n\
 import {createInlineWorkerFactory} from 'rollup-plugin-web-worker-loader::helper';\n\
-var WorkerFactory = createInlineWorkerFactory(${source.substring(0, source.length - 1)}, ${sourcemap ? "'" + sourcemap.toUrl() + "'" : 'null'});\n\
+var WorkerFactory = createInlineWorkerFactory(${source.substring(0, source.length - 1)}, ${sourcemap ? `'${sourcemap.toUrl()}'` : 'null'});\n\
 export default WorkerFactory;\n\
 /* eslint-enable */\n`;
         }
@@ -46,7 +46,7 @@ export default WorkerFactory;\n\
         return `\
 /* eslint-disable */\n\
 import {createBase64WorkerFactory} from 'rollup-plugin-web-worker-loader::helper';\n\
-var WorkerFactory = createBase64WorkerFactory('${Buffer.from(source, enableUnicode ? 'utf16le' : 'utf8').toString('base64')}', ${sourcemap ? "'" + sourcemap.toUrl() + "'" : 'null'}, ${enableUnicode.toString()});\n\
+var WorkerFactory = createBase64WorkerFactory('${Buffer.from(source, enableUnicode ? 'utf16le' : 'utf8').toString('base64')}', ${sourcemap ? `'${sourcemap.toUrl()}'` : 'null'}, ${enableUnicode.toString()});\n\
 export default WorkerFactory;\n\
 /* eslint-enable */\n`;
     }


### PR DESCRIPTION
This modifies the inline code to be ES5-compatible. Tested locally in IE11, which appears to be resolved with this fix.

Fixes #15 