### PR TITLE
Swap `const` for `var` in isNodeJS.js helper

### DIFF
--- a/src/helper/auto/isNodeJS.js
+++ b/src/helper/auto/isNodeJS.js
@@ -1,4 +1,4 @@
-const kIsNodeJS = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+var kIsNodeJS = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
 
 export function isNodeJS() {
     return kIsNodeJS;


### PR DESCRIPTION
Relating to #16, this `const` appears in our build output and is not being transpiled as part of our build, presumably because of the way this file [is imported as a virtual module](https://github.com/darionco/rollup-plugin-web-worker-loader/blob/master/src/helper/auto/createBase64WorkerFactory.js#L3) after the recent refactoring of the code. Therefore, the plugin breaks code intended for an ES5 build. This would break in IE11. Our case, we use `es-check` to verify that output files are ES5 compatible, which failed due to this `const`.

I've verified using a local environment that changing this fixes our particular issue.