### PR TITLE
Create the blob url lazily so browser target can be imported into SSR environments

### DIFF
--- a/src/helper/browser/createBase64WorkerFactory.js
+++ b/src/helper/browser/createBase64WorkerFactory.js
@@ -10,15 +10,20 @@ function decodeBase64(base64, enableUnicode) {
     return binaryString;
 }
 
-export function createBase64WorkerFactory(base64, sourcemapArg, enableUnicodeArg) {
+function createURL(base64, sourcemapArg, enableUnicodeArg) {
     var sourcemap = sourcemapArg === undefined ? null : sourcemapArg;
     var enableUnicode = enableUnicodeArg === undefined ? false : enableUnicodeArg;
     var source = decodeBase64(base64, enableUnicode);
     var start = source.indexOf('\n', 10) + 1;
     var body = source.substring(start) + (sourcemap ? '\/\/# sourceMappingURL=' + sourcemap : '');
     var blob = new Blob([body], { type: 'application/javascript' });
-    var url = URL.createObjectURL(blob);
+    return URL.createObjectURL(blob);
+}
+
+export function createBase64WorkerFactory(base64, sourcemapArg, enableUnicodeArg) {
+    var url;
     return function WorkerFactory(options) {
+        url = url || createURL(base64, sourcemapArg, enableUnicodeArg);
         return new Worker(url, options);
     };
 }

--- a/src/helper/browser/createInlineWorkerFactory.js
+++ b/src/helper/browser/createInlineWorkerFactory.js
@@ -9,7 +9,7 @@ function createURL(fn, sourcemapArg) {
 export function createInlineWorkerFactory(fn, sourcemapArg) {
     var url;
     return function WorkerFactory(options) {
-        url = url | createURL(fn, sourcemapArg);
+        url = url || createURL(fn, sourcemapArg);
         return new Worker(url, options);
     };
 }

--- a/src/helper/browser/createInlineWorkerFactory.js
+++ b/src/helper/browser/createInlineWorkerFactory.js
@@ -1,10 +1,15 @@
 import {funcToSource} from '\0rollup-plugin-web-worker-loader::helper::funcToSource';
 
-export function createInlineWorkerFactory(fn, sourcemapArg) {
+function createURL(fn, sourcemapArg) {
     var lines = funcToSource(fn, sourcemapArg);
     var blob = new Blob(lines, { type: 'application/javascript' });
-    var url = URL.createObjectURL(blob);
+    return URL.createObjectURL(blob);
+}
+
+export function createInlineWorkerFactory(fn, sourcemapArg) {
+    var url;
     return function WorkerFactory(options) {
+        url = url | createURL(fn, sourcemapArg);
         return new Worker(url, options);
     };
 }


### PR DESCRIPTION
Our use case is that we have a browser library that we want developers to be able import into SSR apps like gatsby, but not use (it's an authentication library, so we don't need it to be used when static pages are being generated in a build) For example:

```js
import Worker from 'web-worker:./my-worker.js';

if (typeof window !== 'undefined') {
  var myWorker = new Worker();
}
```

So in this case we don't need to use `worker_threads` when gatsby builds the node target for generating pages.

If we lazily create the `Blob` url, we can use `targetPlatform` "browser" and still import our library into a Gatsby app without blowing up the build

