### PR TITLE
[FEAT] Override externals

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ webWorkerLoader({
     forceInline?: boolean,          // *EXPERIMENTAL* when inlined, forces the code to be included every time it is imported
                                     // useful when using code splitting: Default: false
 
+    external?: string[],            // *EXPERIMENTAL* override rollup resolution of external module IDs
+                                    // useful to inline external dependencies in a worker blob. Default: undefined
+
     preserveSource?: boolean,       // When inlined and this option is enabled, the full source code is included in the
                                     // built file, otherwise it's embedded as a base64 string. Default: false
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const defaultConfig = {
     pattern: /web-worker:(.+)/,
     inline: true,
     forceInline: false,
+    external: undefined,
     extensions: [ '.js' ],
     outputFolder: '',
     skipPlugins: [

--- a/src/plugin/load.js
+++ b/src/plugin/load.js
@@ -75,6 +75,9 @@ function load(state, config, addWatchFile, id) {
             const {inputOptions, workerID, target} = state.idMap.get(id);
             state.exclude.add(id);
             state.exclude.add(target);
+            if (config.external) {
+                inputOptions.external = config.external;
+            }
             rollup.rollup(inputOptions).then(bundle => {
                 state.exclude.delete(id);
                 state.exclude.delete(target);


### PR DESCRIPTION
**What this pull request does**
This pull request enables the consumer to configure the list of external rollup module IDs. Any value set to the `external` configuration property overrides the inherited [rollup `external` option](https://rollupjs.org/guide/en/#external) with the value provided.

**What this pull request contains**
- implementation
- documentation

**Further notes**
My use case is creating a library with an inlined webworker to be used by downstream projects on different platforms. To achieve this, the bundled webworker needs to contain all transpiled imports, as downstream bundlers will not be able to package additional dependencies into the blob. By setting the newly introduced property `external: []`, I can instruct rollup to consider no imports as external and bundle them into the worker blob. Which I can then savely distribute as functional part of my library.

Let me know what You think! :balloon: