### PR TITLE
fix: disable sourcemap on default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const generateBundle = require('./plugin/generateBundle');
 
 const defaultConfig = {
     targetPlatform: 'auto',
-    sourcemap: 'false',
+    sourcemap: false,
     loadPath: '',
     preserveSource: false,
     preserveFileNames: false,


### PR DESCRIPTION
js cast 'false' string to true here https://github.com/darionco/rollup-plugin-web-worker-loader/blob/master/src/plugin/load.js#L48
so source map enabled on default now )