### PR TITLE
Add pure notation

### DIFF
--- a/src/utils/buildWorkerCode.js
+++ b/src/utils/buildWorkerCode.js
@@ -43,7 +43,7 @@ export default base64;
     return `
 /* eslint-disable */
 import {${factoryFuncName}} from '\0rollup-plugin-web-worker-loader::helper::${options.targetPlatform}::${factoryFuncName}';
-var WorkerFactory = ${factoryFuncName}(${argsString});
+var WorkerFactory = /*#__PURE__*/${factoryFuncName}(${argsString});
 export default WorkerFactory;
 /* eslint-enable */\n`;
 }


### PR DESCRIPTION
comment should fix tree shaking, because now minifiers can't safely remove worker creation function even it unused.

this code is untouched by specified plugins, so i can't do it with `babel-plugin-annotate-pure-calls`  or samething like