### PR TITLE
Fix for multiple rollup output formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ module.exports = function workerLoaderPlugin(userConfig = null) {
         options: null,
         basePath: null,
         forceInlineCounter: 0,
-        configuredFileName: null,
+        configuredFileNames: new Map(),
     };
 
     return {

--- a/src/plugin/generateBundle.js
+++ b/src/plugin/generateBundle.js
@@ -1,7 +1,7 @@
 function generateBundle(state, config, options, bundle, isWrite) {
     if (!config.inline && isWrite) {
-        if (state.configuredFileName && Object.keys(bundle).length === 1) {
-            bundle[Object.keys(bundle)[0]].fileName = state.configuredFileName;
+        if (state.configuredFileNames.size > 0 && Object.keys(bundle).length === 1) {
+            bundle[Object.keys(bundle)[0]].fileName = state.configuredFileNames.get(options.format);
         }
         for (const worker of state.idMap) {
             if (worker[1].chunk && !bundle[worker[1].workerID]) {

--- a/src/plugin/outputOptions.js
+++ b/src/plugin/outputOptions.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 function outputOptions(state, config, options) {
     if (!config.inline && options.file && !options.dir) {
-        state.configuredFileName = path.basename(options.file);
+        state.configuredFileNames.set(options.format, path.basename(options.file));
         return Object.assign({}, options, {
             file: null,
             dir: path.dirname(options.file),


### PR DESCRIPTION
I changed `state.configuredFileName` from a single value into a `state.configuredFileNames` map so that it can keep track of multiple file names when multiple output formats are specified in a rollup config.

Fixes #64 