### PR TITLE
Fix unicode decoding

### DIFF
--- a/src/helper/browser/createBase64AudioWorkletFactory.js
+++ b/src/helper/browser/createBase64AudioWorkletFactory.js
@@ -5,7 +5,8 @@ function decodeBase64(base64, enableUnicode) {
         for (var i = 0, n = binaryString.length; i < n; ++i) {
             binaryView[i] = binaryString.charCodeAt(i);
         }
-        return String.fromCharCode.apply(null, new Uint16Array(binaryView.buffer));
+        const decoder = new TextDecoder("utf-16le")
+        return decoder.decode(new Uint16Array(binaryView.buffer));
     }
     return binaryString;
 }

--- a/src/helper/browser/createBase64PaintWorkletFactory.js
+++ b/src/helper/browser/createBase64PaintWorkletFactory.js
@@ -5,7 +5,8 @@ function decodeBase64(base64, enableUnicode) {
         for (var i = 0, n = binaryString.length; i < n; ++i) {
             binaryView[i] = binaryString.charCodeAt(i);
         }
-        return String.fromCharCode.apply(null, new Uint16Array(binaryView.buffer));
+        const decoder = new TextDecoder("utf-16le")
+        return decoder.decode(new Uint16Array(binaryView.buffer));
     }
     return binaryString;
 }

--- a/src/helper/browser/createBase64ServiceWorkerFactory.js
+++ b/src/helper/browser/createBase64ServiceWorkerFactory.js
@@ -5,7 +5,8 @@ function decodeBase64(base64, enableUnicode) {
         for (var i = 0, n = binaryString.length; i < n; ++i) {
             binaryView[i] = binaryString.charCodeAt(i);
         }
-        return String.fromCharCode.apply(null, new Uint16Array(binaryView.buffer));
+        const decoder = new TextDecoder("utf-16le")
+        return decoder.decode(new Uint16Array(binaryView.buffer));
     }
     return binaryString;
 }

--- a/src/helper/browser/createBase64WorkerFactory.js
+++ b/src/helper/browser/createBase64WorkerFactory.js
@@ -5,7 +5,8 @@ function decodeBase64(base64, enableUnicode) {
         for (var i = 0, n = binaryString.length; i < n; ++i) {
             binaryView[i] = binaryString.charCodeAt(i);
         }
-        return String.fromCharCode.apply(null, new Uint16Array(binaryView.buffer));
+        const decoder = new TextDecoder("utf-16le")
+        return decoder.decode(new Uint16Array(binaryView.buffer));
     }
     return binaryString;
 }


### PR DESCRIPTION
Replaces usage of `String.fromCharCode.apply()` with `TextDecoder.decode()` to avoid exceeding the maximum argument count.

Fixes #66 