### PR TITLE
[OPTIONS] Restore plugins option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ webWorkerLoader({
     loadPath?: string,              // This option is useful when the worker scripts need to be loaded from another folder.
                                     // Default: ''
 
-    skipPlugins?: Array             // Plugin names to skip for web worker build
+    plugins?: Array,                // An array of extra plugins to use while compiling the worker code. Used to apply 
+                                    // transformations to the worker code and not the main code (i.e. minify)
+                                    // NOTE: these plugins be added to the rollop process on top of the plugins in the
+                                    // default configuration.
+                                    // Default: []
+    
+    skipPlugins?: Array,            // Plugin names to skip for web worker build
                                     // Default: [ 'liveServer', 'serve', 'livereload' ]
 })
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rollup-plugin-web-worker-loader",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Rollup plugin to handle Web Workers",
     "main": "src/index.js",
     "repository": "https://github.com/darionco/rollup-plugin-web-worker-loader",

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const defaultConfig = {
     external: undefined,
     extensions: [ '.js' ],
     outputFolder: '',
+    plugins: [],
     skipPlugins: [
         'liveServer',
         'serve',

--- a/src/plugin/options.js
+++ b/src/plugin/options.js
@@ -11,6 +11,7 @@ function optionsImp(state, config, options) {
                 }
                 plugins.push(plugin);
             });
+            plugins.push(...config.plugins);
             state.options.plugins = plugins;
 
             const cwd = process.cwd();


### PR DESCRIPTION
### Description

In version 1.6.1, the `plugins` feature was introduced, greatly enhancing our project's flexibility and extensibility. This feature has proven very useful, as my colleagues have successfully used it in our repository. However, we noticed that it was removed in version 1.7.0, which has affected our current workflow.
[code](https://github.com/open-mmlab/labelbee/blob/c69433c5c7b8711b96c4290f38082a27d9007996/packages/lb-components/rollup.config.js#L65)

### Questions and Concerns

Given the importance of the `plugins` feature to our work, we would like to understand the rationale behind its removal:
- Was it due to certain bugs or issues, or was it part of an architectural change?
- Are there alternative solutions that were considered?

### Proposed Solution

This PR restores the `plugins` feature to address the challenges arising from its absence. If any issues persist after the reintroduction, we are more than willing to collaborate on further adjustments and improvements.

### Request

- We kindly ask the maintainers to review this PR and share any insights or discussions related to the removal of the feature.
- If there are no significant concerns, please consider merging this PR to reinstate the `plugins` functionality.

Thank you for taking the time to review these changes, and for your continued support and guidance!
